### PR TITLE
update workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
+          cache: false # only caches go projects, not general go pkgs
 
       - name: get go cache env
         id: go-cache-env
@@ -46,6 +47,10 @@ jobs:
       - name: get version number
         id: find_version
         run: echo "NEW_VERSION=$(git describe --always --tags)" >> $GITHUB_OUTPUT
+
+      - run: |
+          echo "# Version" >> $GITHUB_STEP_SUMMARY
+          echo "${{steps.find_version.outputs.NEW_VERSION}}" >> $GITHUB_STEP_SUMMARY
 
       - name: Set new version number (default branch or tagged build)
         if: ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')))
@@ -107,6 +112,7 @@ jobs:
         run: zip -rq hackclub-modded-packwiz pw-modpack/  # hackclub-modded-packwiz.zip
 
       - name: Create Modrinth Release
+        id: modrinth-release
         if: false
         uses: Kir-Antipov/mc-publish@v3.2
         with:
@@ -120,6 +126,7 @@ jobs:
           game-versions: 1.18.2
 
       - name: Create Github Release
+        id: github-release
         uses: softprops/action-gh-release@v1
         with:
           generate_release_notes: ${{ !(contains(github.ref, '-rc.')) }}
@@ -127,3 +134,13 @@ jobs:
           files: |
             hackclub-modded.mrpack
             hackclub-modded-packwiz.zip
+      - if: ((steps.github-release.conclusion == 'success') || (steps.modrinth-release.conclusion == 'success'))
+        run: echo "# Releases" >> $GITHUB_STEP_SUMMARY
+
+      - if: steps.github-release.conclusion == 'success'
+        run: |
+          echo "- [Github](${{ steps.github-release.outputs.url }})" >> $GITHUB_STEP_SUMMARY
+
+      - if: steps.modrinth-release.conclusion == 'success'
+        run: |
+          echo "- [Modrinth](https://modrinth.com/modpacks/${{secrets.MODRINTH_PROJECT}}/versions)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,10 +44,11 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: "packwiz-modpack"
-          path: | # TODO: parse .packwiz ignore? add all other files?
+          path: |
             pack.toml
             index.toml
             mods/
+            README.md
 
       - name: Cache Mods
         id: cache-mods

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,15 +24,20 @@ jobs:
       - name: get go cache env
         id: go-cache-env
         run: |
-          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
-          echo "GOCACHE=$(go env go env GOCACHE)" >> $GITHUB_OUTPUT
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "GOMODCACHE<<$EOF" >> $GITHUB_ENV
+          go env GOMODCACHE >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
+          echo "GOCACHE<<$EOF" >> $GITHUB_ENV
+          go env GOCACHE >> $GITHUB_ENV
+          echo "$EOF" >> $GITHUB_ENV
 
       - name: cache go
         uses: actions/cache@v3
         with:
           path: |
-            ${{steps.go-cache-env.outputs.GOMODCACHE}}
-            ${{steps.go-cache-env.outputs.GOCACHE}}
+            ${{env.GOMODCACHE}}
+            ${{env.GOCACHE}}
           key: ${{ runner.os }}-gomod
 
       - name: install packwiz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Fetch Repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # checkout non-detached, so git describe works
       - name: get go for packwiz
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,25 +44,34 @@ jobs:
       - name: install packwiz
         run: go install github.com/packwiz/packwiz@latest
 
-      - name: get version number
+      - name: get base version number
         id: find_version
         run: echo "NEW_VERSION=$(git describe --always --tags)" >> $GITHUB_OUTPUT
 
-      - run: |
-          echo "# Version" >> $GITHUB_STEP_SUMMARY
-          echo "${{steps.find_version.outputs.NEW_VERSION}}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Set new version number (default branch or tagged build)
+      - name: Set new version number (default branch / tagged build)
         if: ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')))
-        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}\"~g" pack.toml
+        run: |
+          SET_VERSION="${{steps.find_version.outputs.NEW_VERSION}}"
+          sed -i "s~version = \"dev\"~version = \"$SET_VERSION\"~g" pack.toml
+          echo "SET_VERSION=${SET_VERSION}" >> $GITHUB_ENV
 
       - name: Set new version number (PR)
         if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == 'pull_request'))
-        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"~g" pack.toml
+        run: |
+          SET_VERSION="${{steps.find_version.outputs.NEW_VERSION}}+PR$(echo "${{ github.ref_name }}" | sed "s~/merge~~g")"
+          sed -i "s~version = \"dev\"~version = \"$SET_VERSION\"~g" pack.toml
+          echo "SET_VERSION=${SET_VERSION}" >> $GITHUB_ENV
 
       - name: Set new version number (Other branch)
         if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pull_request') && !(startsWith(github.ref, 'refs/tags/')))
-        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"~g" pack.toml
+        run: |
+          SET_VERSION="${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}"
+          sed -i "s~version = \"dev\"~version = \"$SET_VERSION\"~g" pack.toml
+          echo "SET_VERSION=${SET_VERSION}" >> $GITHUB_ENV
+
+      - run: |
+          echo "# Version" >> $GITHUB_STEP_SUMMARY
+          echo "${{env.SET_VERSION}}" >> $GITHUB_STEP_SUMMARY
 
       - name: generate hashes
         run: packwiz refresh --build
@@ -144,3 +153,17 @@ jobs:
       - if: steps.modrinth-release.conclusion == 'success'
         run: |
           echo "- [Modrinth](https://modrinth.com/modpacks/${{secrets.MODRINTH_PROJECT}}/versions)" >> $GITHUB_STEP_SUMMARY
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fetch Packwiz Modpack
+        uses: actions/download-artifact@v3
+        with:
+          name: packwiz-modpack
+          path: pw-modpack
+
+      - name: Deploy production
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: pw-modpack
+          target-folder: v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,15 +54,15 @@ jobs:
 
       - name: Set new version number (default branch or tagged build)
         if: ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')))
-        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}\"/g" pack.toml
+        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}\"~g" pack.toml
 
       - name: Set new version number (PR)
-        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == 'pr'))
-        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"/g" pack.toml
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == 'pull_request'))
+        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"~g" pack.toml
 
       - name: Set new version number (Other branch)
-        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pr') && !(startsWith(github.ref, 'refs/tags/')))
-        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"/g" pack.toml
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pull_request') && !(startsWith(github.ref, 'refs/tags/')))
+        run: sed -i "s~version = \"dev\"~version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"~g" pack.toml
 
       - name: generate hashes
         run: packwiz refresh --build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: get version number
         id: find_version
-        run: echo "NEW_VERSION=$(git describe --always)" >> $GITHUB_OUTPUT
+        run: echo "NEW_VERSION=$(git describe --always --tags)" >> $GITHUB_OUTPUT
 
       - name: Set new version number (default branch or tagged build)
         if: ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')))

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,30 +1,50 @@
 name: build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - v*.*.*
+      - v*.*.*-rc.*
+  pull_request:
 jobs:
-  build:
+  build-artifacts:
     name: Build modpack
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-go@v4
+      - name: Fetch Repo
+        uses: actions/checkout@v3
+      - name: get go for packwiz
+        uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-
-      - name: Install Packwiz
+      - name: install packwiz # TODO better caching
         run: go install github.com/packwiz/packwiz@latest
 
-      - name: Replace version number
-        run: sed -i "s/version = \"dev\"/version = \"$(git describe --always)\"/g" pack.toml
+      - name: get version number
+        id: find_version
+        run: echo "NEW_VERSION=$(git describe --always)" >> $GITHUB_OUTPUT
 
-      - name: refresh modpack
+      - name: Set new version number (default branch or tagged build)
+        if: (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')
+        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}\"/g" pack.toml
+
+      - name: Set new version number (PR)
+        if: (github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == "pr")
+        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"/g" pack.toml
+
+      - name: Set new version number (Other branch)
+        if: (github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != "pr") && !(startsWith(github.ref, 'refs/tags/')
+        run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"/g" pack.toml
+
+      - name: generate hashes
         run: packwiz refresh --build
 
       - name: upload artifact (packwiz)
         uses: actions/upload-artifact@v3
         with:
-          name: "modpack (packwiz format)"
-          path: | 
+          name: "packwiz-modpack"
+          path: | # TODO: parse .packwiz ignore? add all other files?
             pack.toml
             index.toml
             mods/
@@ -43,6 +63,43 @@ jobs:
       - name: upload artifact (modrinth)
         uses: actions/upload-artifact@v3
         with:
-          name: "modpack (modrinth format)"
+          name: "modrinth-modpack"
           path: "hackclub-modded.mrpack"
+  release:
+    if: ${{ github.ref_type == 'tag' }}
+    name: Release to modrinth and github
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fetch Modrinth Modpack
+        uses: actions/download-artifact@v3
+        with:
+          name: modrinth-modpack
+      - name: Fetch Packwiz Modpack
+        uses: actions/download-artifact@v3
+        with:
+          name: packwiz-modpack
+          path: pw-modpack
+      - name: Create hackclubmodpack.zip
+        run: zip -rq hackclub-modded-packwiz pw-modpack/  # hackclub-modded-packwiz.zip
 
+      - name: Create Modrinth Release
+        if: false
+        uses: Kir-Antipov/mc-publish@v3.2
+        with:
+          modrinth-id: ${{ secrets.MODRINTH_PROJECT }}
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          modrinth-featured: ${{ !(contains(github.ref, '-rc.')) }}
+          modrinth-unfeature-mode: ${{ (contains(github.ref, '-rc.')) && 'none') || 'any' }} # "any" if production deploy, none otherwise
+          files-primary: "hackclub-modded.mrpack"
+          files-extra: "hackclub-modded-packwiz.zip"
+          version-type: ${{ (contains(github.ref, '-rc.')) && 'beta') || 'release' }}
+          game-versions: 1.18.2
+
+      - name: Create Github Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: ${{ !(contains(github.ref, '-rc.')) }}
+          prerelease: ${{ contains(github.ref, '-rc.') }}
+          files: |
+            hackclub-modded.mrpack
+            hackclub-modded-packwiz.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,6 +155,8 @@ jobs:
           echo "- [Modrinth](https://modrinth.com/modpacks/${{secrets.MODRINTH_PROJECT}}/versions)" >> $GITHUB_STEP_SUMMARY
   deploy:
     runs-on: ubuntu-22.04
+    needs: build-artifacts
+    if: false # tmp
     steps:
       - name: Fetch Packwiz Modpack
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,11 +30,11 @@ jobs:
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}\"/g" pack.toml
 
       - name: Set new version number (PR)
-        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == "pr"))
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == 'pr'))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"/g" pack.toml
 
       - name: Set new version number (Other branch)
-        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != "pr") && !(startsWith(github.ref, 'refs/tags/'))
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pr') && !(startsWith(github.ref, 'refs/tags/'))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"/g" pack.toml
 
       - name: generate hashes

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,22 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.20"
-      - name: install packwiz # TODO better caching
+
+      - name: get go cache env
+        id: go-cache-env
+        run: |
+          echo "GOMODCACHE=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "GOCACHE=$(go env go env GOCACHE)" >> $GITHUB_OUTPUT
+
+      - name: cache go
+        uses: actions/cache@v3
+        with:
+          path: |
+            ${{steps.go-cache-env.outputs.GOMODCACHE}}
+            ${{steps.go-cache-env.outputs.GOCACHE}}
+          key: ${{ runner.os }}-gomod
+
+      - name: install packwiz
         run: go install github.com/packwiz/packwiz@latest
 
       - name: get version number

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"/g" pack.toml
 
       - name: Set new version number (Other branch)
-        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pr') && !(startsWith(github.ref, 'refs/tags/'))
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != 'pr') && !(startsWith(github.ref, 'refs/tags/')))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"/g" pack.toml
 
       - name: generate hashes

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,6 +66,7 @@ jobs:
           name: "modrinth-modpack"
           path: "hackclub-modded.mrpack"
   release:
+    needs: build-artifacts
     if: ${{ github.ref_type == 'tag' }}
     name: Release to modrinth and github
     runs-on: ubuntu-22.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,15 +26,15 @@ jobs:
         run: echo "NEW_VERSION=$(git describe --always)" >> $GITHUB_OUTPUT
 
       - name: Set new version number (default branch or tagged build)
-        if: (github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')
+        if: ((github.ref == format('refs/heads/{0}', github.event.repository.default_branch)) || (startsWith(github.ref, 'refs/tags/')))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}\"/g" pack.toml
 
       - name: Set new version number (PR)
-        if: (github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == "pr")
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name == "pr"))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+PR${{ github.ref_name }}\"/g" pack.toml
 
       - name: Set new version number (Other branch)
-        if: (github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != "pr") && !(startsWith(github.ref, 'refs/tags/')
+        if: ((github.ref != format('refs/heads/{0}', github.event.repository.default_branch)) && (github.event_name != "pr") && !(startsWith(github.ref, 'refs/tags/'))
         run: sed -i "s/version = \"dev\"/version = \"${{steps.find_version.outputs.NEW_VERSION}}+${{ github.ref_name }}\"/g" pack.toml
 
       - name: generate hashes
@@ -89,10 +89,10 @@ jobs:
           modrinth-id: ${{ secrets.MODRINTH_PROJECT }}
           modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
           modrinth-featured: ${{ !(contains(github.ref, '-rc.')) }}
-          modrinth-unfeature-mode: ${{ (contains(github.ref, '-rc.')) && 'none') || 'any' }} # "any" if production deploy, none otherwise
+          modrinth-unfeature-mode: ${{ ((contains(github.ref, '-rc.')) && 'none') || 'any' }} # "any" if production deploy, none otherwise
           files-primary: "hackclub-modded.mrpack"
           files-extra: "hackclub-modded-packwiz.zip"
-          version-type: ${{ (contains(github.ref, '-rc.')) && 'beta') || 'release' }}
+          version-type: ${{ ((contains(github.ref, '-rc.')) && 'beta') || 'release' }}
           game-versions: 1.18.2
 
       - name: Create Github Release


### PR DESCRIPTION
to release a version, `git tag -as v1.0.0`, followed by `git push --tags`
to pre-release a version, appennd -rc.[rcnum] to the tag

to enable modrinth, add the two secrets, and edit the file to remove the if: false
i would probably recommend squash commiting this?